### PR TITLE
chore: Adding AWS Events content link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This repository contains slides, demos, and other assets for the Kubernetes (KUB
 - [EKS Workshop](https://www.eksworkshop.com/) - Practical exercises to learn about Amazon Elastic Kubernetes Service.
 - [EKS Best Practices Guide](https://docs.aws.amazon.com/eks/latest/best-practices/introduction.html) - Build your Amazon EKS knowledge.
 - [Amazon EKS - Knowledge Badge Readiness Path](https://explore.skillbuilder.aws/learn/public/learning_plan/view/1931/amazon-eks-knowledge-badge-readiness-path) - Earn a badge at the end of this Amazon EKS learning path.
+- [AWS Events Content](https://aws.amazon.com/events/events-content/) - Official content from AWS Events sessions, including slide decks.
 
 ## Request an EKS Workshop
 [AWS Guided EKS Workshop](https://pages.awscloud.com/NAMER-other-PT-eks-workshop-2024-reg.html?trk=93273282-cba3-45ac-932f-841b45264eee&sc_channel=el)

--- a/sessions/KUB302/README.md
+++ b/sessions/KUB302/README.md
@@ -7,6 +7,8 @@ As part of designing any modern system on AWS, it is necessary to think about th
 ## Related Resources
 
 [EKS Security Best Practices Guide](https://docs.aws.amazon.com/eks/latest/best-practices/security.html)
+[One Observability Workshop](https://catalog.workshops.aws/observability/en-US)
+[EKS Workshop - Security](https://www.eksworkshop.com/docs/security/)
 
 [Amazon EKS and Kubernetes sessions at AWS re:Invent 2024](https://aws.amazon.com/blogs/containers/amazon-eks-and-kubernetes-sessions-at-aws-reinvent-2024/)
 

--- a/sessions/KUB302/README.md
+++ b/sessions/KUB302/README.md
@@ -2,8 +2,6 @@
 
 As part of designing any modern system on AWS, it is necessary to think about the security implications and practices that can affect your security posture. This chalk talk walks you through five key areas to apply best practices for improving the overall security of containerized environments on Amazon EKS using a sample architecture. Learn how to leverage the security footprint on access control, software supply chain, cluster infrastructure, runtime, and data protection.
 
-[Overview of Amazon EKS and Kubernetes sessions at AWS re:Invent 2024](https://aws.amazon.com/blogs/containers/amazon-eks-and-kubernetes-sessions-at-aws-reinvent-2024)
-
 ## Related Resources
 
 [EKS Security Best Practices Guide](https://docs.aws.amazon.com/eks/latest/best-practices/security.html)

--- a/sessions/KUB302/README.md
+++ b/sessions/KUB302/README.md
@@ -7,7 +7,6 @@ As part of designing any modern system on AWS, it is necessary to think about th
 ## Related Resources
 
 [EKS Security Best Practices Guide](https://docs.aws.amazon.com/eks/latest/best-practices/security.html)
-[One Observability Workshop](https://catalog.workshops.aws/observability/en-US)
 [EKS Workshop - Security](https://www.eksworkshop.com/docs/security/)
 
 [Amazon EKS and Kubernetes sessions at AWS re:Invent 2024](https://aws.amazon.com/blogs/containers/amazon-eks-and-kubernetes-sessions-at-aws-reinvent-2024/)

--- a/sessions/KUB305/README.md
+++ b/sessions/KUB305/README.md
@@ -4,13 +4,13 @@ In this hands-on session, explore how to automate the identification, analysis, 
 
 [Securing and Observing EKS GitHub repo](https://github.com/aws-samples/securing-and-observing-eks) - Holds the content to deploy the environment to run this workshop in your own account.
 
-[Overview of Amazon EKS and Kubernetes sessions at AWS re:Invent 2024](https://aws.amazon.com/blogs/containers/amazon-eks-and-kubernetes-sessions-at-aws-reinvent-2024)
-
 ## Related Resources
 
 [EKS Security Best Practices Guide](https://docs.aws.amazon.com/eks/latest/best-practices/security.html)
 [One Observability Workshop](https://catalog.workshops.aws/observability/en-US)
 [EKS Workshop - Security](https://www.eksworkshop.com/docs/security/)
+
+[Overview of Amazon EKS and Kubernetes sessions at AWS re:Invent 2024](https://aws.amazon.com/blogs/containers/amazon-eks-and-kubernetes-sessions-at-aws-reinvent-2024)
 
 ## Related Sessions
 

--- a/sessions/KUB305/README.md
+++ b/sessions/KUB305/README.md
@@ -2,6 +2,8 @@
 
 In this hands-on session, explore how to automate the identification, analysis, and mitigation of risks in Amazon Elastic Kubernetes Service (Amazon EKS) clusters. Learn how to implement robust security controls—including role-based access control (RBAC), EKS Pod Identity, and service accounts—to apply least-privilege access and secure workload isolation. Also discover how to use AWS CloudTrail and Amazon CloudWatch to gain deep visibility into EKS cluster activities, enabling real-time monitoring and automated risk detection. Learn the skills to automate risk management processes, helping your Kubernetes workloads remain resilient against evolving threats. You must bring your laptop to participate.
 
+[Securing and Observing EKS GitHub repo](https://github.com/aws-samples/securing-and-observing-eks) - Holds the content to deploy the environment to run this workshop in your own account.
+
 [Overview of Amazon EKS and Kubernetes sessions at AWS re:Invent 2024](https://aws.amazon.com/blogs/containers/amazon-eks-and-kubernetes-sessions-at-aws-reinvent-2024)
 
 ## Related Resources

--- a/sessions/KUB305/README.md
+++ b/sessions/KUB305/README.md
@@ -7,6 +7,8 @@ In this hands-on session, explore how to automate the identification, analysis, 
 ## Related Resources
 
 [EKS Security Best Practices Guide](https://docs.aws.amazon.com/eks/latest/best-practices/security.html)
+[One Observability Workshop](https://catalog.workshops.aws/observability/en-US)
+[EKS Workshop - Security](https://www.eksworkshop.com/docs/security/)
 
 ## Related Sessions
 


### PR DESCRIPTION
*Description of changes:*

Adding the link for the audience to access official content from AWS Events under the General Resources on main README.

Adding links to related workshops on KUB305 and KUB302

